### PR TITLE
fix: improve background logo opacity for mobile browsers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
             <img
               src={sphSpadeLogo}
               alt="SPH Spade Logo Background"
-              className="w-[80vw] h-[80vw] sm:w-[60vw] sm:h-[60vw] md:w-[50vw] md:h-[50vw] lg:w-[40vw] lg:h-[40vw] xl:w-[35vw] xl:h-[35vw] max-w-[800px] max-h-[800px] object-contain opacity-3 sm:opacity-5 md:opacity-8"
+              className="bg-logo w-[80vw] h-[80vw] sm:w-[60vw] sm:h-[60vw] md:w-[50vw] md:h-[50vw] lg:w-[40vw] lg:h-[40vw] xl:w-[35vw] xl:h-[35vw] max-w-[800px] max-h-[800px] object-contain"
             />
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -49,4 +49,27 @@
     background: #ffd700;
     color: #1a1a1a;
   }
+
+  /* Background logo styling for better cross-browser compatibility */
+  .bg-logo {
+    opacity: 0.03 !important;
+    filter: blur(0.5px);
+    mix-blend-mode: overlay;
+    /* Fallback for older browsers */
+    -webkit-opacity: 0.03;
+    -moz-opacity: 0.03;
+    /* Ensure it's very subtle */
+    will-change: auto;
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+  }
+
+  /* Additional fallback for very old mobile browsers */
+  @media screen and (max-width: 768px) {
+    .bg-logo {
+      opacity: 0.02 !important;
+      -webkit-opacity: 0.02;
+      -moz-opacity: 0.02;
+    }
+  }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,5 +37,6 @@ export default {
     "bg-gradient-to-br",
     "from-dark-bg",
     "to-dark-secondary",
+    "bg-logo",
   ],
 };


### PR DESCRIPTION
- Replace Tailwind opacity classes with custom CSS for better compatibility
- Add cross-browser fallbacks (-webkit-opacity, -moz-opacity)
- Use mix-blend-mode and blur filter for enhanced fading effect
- Add mobile-specific opacity adjustments (0.02 on mobile, 0.03 on desktop)
- Include will-change and backface-visibility for performance
- Add bg-logo class to Tailwind safelist