### PR TITLE
fix: remove bilingual titles from section headers

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -59,7 +59,7 @@
   },
   "sections": {
     "general": {
-      "title": "General Rules / Normas Generales",
+      "title": "General Rules",
       "rules": [
         "Respect and good conduct: Zero tolerance for disrespect, toxicity, racism, xenophobia, or personal attacks. This also applies to the command chat! We want a healthy community.",
         "Use of the SPH tag: Only official community members can use the SPH tag. Improper use will result in a kick or ban.",
@@ -74,7 +74,7 @@
       ]
     },
     "squad": {
-      "title": "Squad Rules / Reglas para Escuadrones",
+      "title": "Squad Rules",
       "rules": [
         "Squad leader with mic: A microphone is mandatory for all squad leaders (SL).",
         "Languages: If you lead in a language other than Spanish, indicate it in the squad name.",
@@ -84,7 +84,7 @@
       ]
     },
     "infantry": {
-      "title": "Infantry Rules / Reglas para Infantería",
+      "title": "Infantry Rules",
       "rules": [
         "Squads without functional SL: Squads without a leader using the SL kit or without a microphone will be disbanded by admins. You may switch kits for specific situations (e.g., saving a radio, using AT against a vehicle near the HAB, etc.).",
         "Creating squads without leading is forbidden: If you create a squad and do not lead it, you will be banned.",
@@ -93,7 +93,7 @@
       ]
     },
     "vehicles": {
-      "title": "Vehicles / Vehículos",
+      "title": "Vehicles",
       "rules": [
         "Helicopters: They can only be crewed by 1 to 2 people; for SPH members, up to 4 people. The helicopter must prioritize the needs of the team over those of its squad.",
         "One specialized vehicle per squad: You cannot use more than one armored vehicle or helicopter per squad at the same time.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -59,7 +59,7 @@
   },
   "sections": {
     "general": {
-      "title": "Normas Generales / General Rules",
+      "title": "Normas Generales",
       "rules": [
         "Respeto y buena conducta: Cero tolerancia a faltas de respeto, toxicidad, racismo, xenofobia o ataques personales. ¡También aplica al chat de comandancia! Queremos una comunidad sana.",
         "Uso del tag SPH: Solo los miembros oficiales de la comunidad pueden usar el tag SPH. El uso indebido implica kick o ban.",
@@ -74,7 +74,7 @@
       ]
     },
     "squad": {
-      "title": "Reglas para Escuadrones / Squad Rules",
+      "title": "Reglas para Escuadrones",
       "rules": [
         "Líder con micrófono: El uso de micrófono es obligatorio para todos los líderes de escuadra (SL).",
         "Idiomas: Si lideras en un idioma distinto al español, indícalo en el nombre del escuadrón.",
@@ -84,7 +84,7 @@
       ]
     },
     "infantry": {
-      "title": "Reglas para Infantería / Infantry Rules",
+      "title": "Reglas para Infantería",
       "rules": [
         "Escuadras sin SL funcional: Las escuadras sin líder con kit de SL o sin micrófono serán disueltas por los admins. Podrás cambiarte el kit para situaciones específicas (ej. salvar una radio, AT para un vehículo cerca del HAB, etc).",
         "Prohibido crear escuadras sin líder: Si creas una escuadra y no lideras, serás baneado.",
@@ -93,7 +93,7 @@
       ]
     },
     "vehicles": {
-      "title": "Vehículos / Vehicles",
+      "title": "Vehículos",
       "rules": [
         "Helicópteros: Solo pueden ser ocupados por 1 a 2 personas, para miembros de SPH hasta 4 personas. El helicóptero priorizará las necesidades del equipo antes que la de su squad.",
         "Un vehículo especializado por escuadra: No puedes usar más de un blindado o helicóptero a la vez por escuadra.",


### PR DESCRIPTION
- Remove English text from Spanish section titles
- Remove Spanish text from English section titles
- Keep only single language per title since language selector handles switching
- Maintains translation key consistency