### PR TITLE
feat: rename Support tab to RRSS/Social Media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.1] - 2025-09-28
+### Features
+  - Change support section to social media section
+
+## [0.1.0] - 2025-09-28
+  - Initial release

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "sph-sq-rules",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
-  "author": "Alejandro L. Herrero <alejandrolhc@gmail.com>",
+  "author": "Alejandro L. Herrero @AlejandroLuisHC <alejandrolhc@gmail.com>",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -5,7 +5,7 @@
     "home": "Home",
     "rules": "Rules",
     "sanctions": "Sanctions Table",
-    "support": "Support"
+    "support": "Social Media"
   },
   "home": {
     "description": "Welcome to the SPH Squad server. Here you'll find all the rules and guidelines for a fair and fun gaming experience for all players.",
@@ -19,7 +19,7 @@
         "description": "A server with a respectful community and committed administrators."
       },
       "support": {
-        "title": "24/7 Support",
+        "title": "24/7 Social Media",
         "description": "Reporting system and support to maintain a healthy gaming environment."
       }
     }
@@ -127,7 +127,7 @@
       ]
     },
     "support": {
-      "title": "Support",
+      "title": "Social Media",
       "rules": [
         "Contact with administration: To contact the administration team, you can do so through the game chat by typing !admin and a description, e.g.; !admin the SL of squad 2 on the Russian side has no mic or kit. Please note that there may not be any administrator playing on the server at that time.",
         "Serious reports: Similarly, if it is necessary to ban a player from the server for more serious issues such as racism, discrimination, etc., you must open a ticket on our Discord, if possible providing evidence.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -5,7 +5,7 @@
     "home": "Inicio",
     "rules": "Reglas",
     "sanctions": "Tabla de Sanciones",
-    "support": "Soporte"
+    "support": "RRSS"
   },
   "home": {
     "description": "Bienvenido al servidor SPH Squad. Aquí encontrarás todas las reglas y directrices para una experiencia de juego justa y divertida para todos los jugadores.",
@@ -19,7 +19,7 @@
         "description": "Un servidor con una comunidad respetuosa y administradores comprometidos."
       },
       "support": {
-        "title": "Soporte 24/7",
+        "title": "RRSS 24/7",
         "description": "Sistema de reportes y soporte para mantener un ambiente de juego saludable."
       }
     }
@@ -127,7 +127,7 @@
       ]
     },
     "support": {
-      "title": "Soporte",
+      "title": "RRSS",
       "rules": [
         "Contacto con administración: Para contactar con el equipo de administración puede hacerlo por el chat del juego escribiendo !admin y una descripción, ej; !admin el SL de la 2 en el bando ruso no tiene micro ni kit. Tenga en cuenta que es posible que en ese momento no haya ningún administrador jugando en el servidor.",
         "Reportes serios: De igual modo si es necesario realizar un ban de algún jugador del servidor por temas más serios como racismo, discriminación, etc., se requiere abrir un ticket en nuestro Discord, si es posible aportando pruebas.",


### PR DESCRIPTION
- Change 'Soporte' to 'RRSS' in Spanish navigation
- Change 'Support' to 'Social Media' in English navigation
- Update all related titles and descriptions
- Maintains translation key consistency